### PR TITLE
op3/t: fix the sepolicy [1/3]

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -59,7 +59,7 @@ TARGET_USES_64_BIT_BINDER := true
 # Kernel
 BOARD_KERNEL_CMDLINE := androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 cma=32M@0-0xffffffff
 BOARD_KERNEL_CMDLINE += androidboot.wificountrycode=US
-BOARD_KERNEL_CMDLINE += androidboot.selinux=permissive
+#BOARD_KERNEL_CMDLINE += androidboot.selinux=permissive
 BOARD_KERNEL_BASE := 0x80000000
 BOARD_KERNEL_PAGESIZE := 4096
 BOARD_KERNEL_TAGS_OFFSET := 0x02000000

--- a/configs/powerhint.xml
+++ b/configs/powerhint.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<!--
+/* Copyright (c) 2016-2017, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2018, The LineageOS Project.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+-->
+<HintConfigs>
+    <Powerhint>
+        <!--preview-->
+        <!-- B CPU - above_hispeed_delay of 40 ms -->
+        <!-- B CPU - go hispeed load 95 -->
+        <!-- B CPU - hispeed freq of 556 MHz -->
+        <!-- B CPU - target load of 90 -->
+        <!-- L CPU - above_hispeed_delay of 40 ms -->
+        <!-- L CPU - go hispeed load 95 -->
+        <!-- L CPU - hispeed freq of 556 MHz- -->
+        <!-- L CPU - target load of 90 -->
+        <!-- CPUBW low power ceil mpbs of 2500 -->
+        <!-- CPUBW low power io percent of 50 -->
+
+        <Config
+            Id="0x00001300" Enable="true" Target="msm8996"
+            Resources="0x41400000, 0x4, 0x41410000, 0x5F, 0x41414000, 0x22C, 0x41420000, 0x5A, 0x41400100, 0x4, 0x41410100, 0x5F
+            , 0x41414100, 0x22C, 0x41420100, 0x5A, 0x41810000, 0x9C4, 0x41814000, 0x32" />
+
+        <!--video encode 30 fps-->
+        <!-- B CPU - above_hispeed_delay of 40 ms -->
+        <!-- B CPU - go hispeed load 95 -->
+        <!-- B CPU - hispeed freq of 806 MHz -->
+        <!-- B CPU - target load of 90 -->
+        <!-- L CPU - above_hispeed_delay of 40 ms -->
+        <!-- L CPU - go hispeed load 95 -->
+        <!-- L CPU - hispeed freq of 556 MHz- -->
+        <!-- L CPU - target load of 90 -->
+        <!-- CPUBW low power ceil mpbs of 2500 -->
+        <!-- CPUBW low power io percent of 50 -->
+        <!-- CPUBW disable hysteresis -->
+        <!-- CPUBW sample_ms of 10ms -->
+        <!-- L CPU - disable ignore_hispeed_notif -->
+        <!-- B CPU - disable ignore_hispeed_notif -->
+        <Config
+            Id="0x00001203" Enable="true" Target="msm8996"
+            Resources="0x41400000, 0x4, 0x41410000, 0x5F ,0x41414000, 0x326, 0x41420000, 0x5A, 0x41400100, 0x4, 0x41410100
+            , 0x5F, 0x41414100, 0x22C, 0x41420100, 0x5A, 0x41810000 ,0x9C4, 0x41814000,
+            0x32, 0x4180C000 ,0x0, 0x41820000, 0xA, 0x41438100, 0x0, 0x41438000, 0x0" />
+
+        <!--video decode-->
+        <!-- L CPU - above_hispeed_delay of 40 ms -->
+        <!-- L CPU - go hispeed load 95 -->
+        <!-- L CPU - hispeed freq of 768 MHz- -->
+        <!-- L CPU - target load of 90 -->
+        <!-- B CPU - above_hispeed_delay of 40 ms -->
+        <!-- B CPU - go hispeed load 95 -->
+        <!-- B CPU - hispeed freq of 729 MHz -->
+        <!-- B CPU - target load of 90 -->
+        <Config
+            Id="0x00001204" Enable="true" Target="msm8996"
+            Resources="0x41400100, 0x4, 0x41410100, 0x5F ,0x41414100, 0x2D9, 0x41420100, 0x5A, 0x41400000, 0x4, 0x41410000
+            , 0x5F, 0x41414000, 0x2D9, 0x41420000, 0x5A" />
+
+        <!--sustained performance-->
+        <!-- B CPU - Cluster min freq uncapped -->
+        <!-- L CPU - Cluster min freq uncapped -->
+        <!-- B CPU - Cluster max freq ~1.2 GHz -->
+        <!-- L CPU - Cluster max freq ~1.2 Ghz -->
+        <!-- GPU - min freq 180 Mhz -->
+        <!-- GPU - max freq 342 Mhz -->
+        <!-- GPUBW freq uncapped -->
+        <Config
+            Id="0x00001206" Enable="true" Target="msm8996"
+            Resources="0x40800000, 0x0, 0x40800100, 0x0, 0x40804000, 0x4E0, 0x40804100, 0x4E0,
+            0x4280C000, 0xB4, 0x42810000, 0x156, 0x42814000, 0x0"/>
+        <!--vr mode-->
+        <!-- B CPU - Cluster min freq ~1.4 Ghz -->
+        <!-- L CPU - Cluster min freq ~1.4 Ghz -->
+        <!-- B CPU - Cluster max freq ~1.4 Ghz -->
+        <!-- L CPU - Cluster max freq ~1.4 Ghz -->
+        <!-- GPU - min freq 510 Mhz -->
+        <!-- GPU - max freq 510 Mhz -->
+        <!-- GPUBW freq 775 Mhz-->
+        <Config
+            Id="0x00001207" Enable="true" Target="msm8996"
+            Resources="0x40800000, 0x579, 0x40800100, 0x579, 0x40804000, 0x579, 0x40804100, 0x579,
+            0x4280C000, 0x203, 0x42810000, 0x203, 0x42814000, 0x1E4F"/>
+
+        <!--vr mode sustained performance-->
+        <!-- B CPU - Cluster min freq ~1.2 Ghz -->
+        <!-- L CPU - Cluster min freq ~1.2 Ghz -->
+        <!-- B CPU - Cluster max freq ~1.2 Ghz -->
+        <!-- L CPU - Cluster max freq ~1.2 Ghz -->
+        <!-- GPU - min freq 342 Mhz -->
+        <!-- GPU - max freq 342 Mhz -->
+        <!-- GPUBW freq 775 Mhz -->
+        <Config
+            Id="0x00001301" Enable="true" Target="msm8996"
+            Resources="0x40800000, 0x4E0, 0x40800100, 0x4E0, 0x40804000, 0x4E0, 0x40804100, 0x4E0, 0x4280C000, 0x156,
+            0x42810000, 0x156, 0x42814000, 0x1E4F"/>
+    </Powerhint>
+</HintConfigs>

--- a/device.mk
+++ b/device.mk
@@ -386,6 +386,7 @@ PRODUCT_PACKAGES += \
 
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/configs/perfboostsconfig.xml:$(TARGET_COPY_OUT_VENDOR)/etc/perf/perfboostsconfig.xml \
+    $(LOCAL_PATH)/configs/powerhint.xml:$(TARGET_COPY_OUT_VENDOR)/etc/powerhint.xml
 
 # Qualcomm
 PRODUCT_COPY_FILES += \

--- a/extract-files.sh
+++ b/extract-files.sh
@@ -24,9 +24,9 @@ VENDOR=oneplus
 MY_DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$MY_DIR" ]]; then MY_DIR="$PWD"; fi
 
-LINEAGE_ROOT="$MY_DIR"/../../..
+XTENDED_ROOT="$MY_DIR"/../../..
 
-HELPER="$LINEAGE_ROOT"/vendor/gzosp/build/tools/extract_utils.sh
+HELPER="$XTENDED_ROOT"/vendor/xtended/build/tools/extract_utils.sh
 if [ ! -f "$HELPER" ]; then
     echo "Unable to find helper script at $HELPER"
     exit 1
@@ -50,7 +50,7 @@ else
 fi
 
 # Initialize the helper
-setup_vendor "$DEVICE" "$VENDOR" "$LINEAGE_ROOT"
+setup_vendor "$DEVICE" "$VENDOR" "$XTENDED_ROOT"
 
 extract "$MY_DIR"/proprietary-files-qc.txt "$SRC"
 extract "$MY_DIR"/proprietary-files-qc-perf.txt "$SRC"
@@ -58,7 +58,7 @@ extract "$MY_DIR"/proprietary-files.txt "$SRC"
 
 "$MY_DIR"/setup-makefiles.sh
 
-CAMERA_HAL="$LINEAGE_ROOT"/vendor/"$VENDOR"/"$DEVICE"/proprietary/vendor/lib/hw/camera.msm8996.so
+CAMERA_HAL="$XTENDED_ROOT"/vendor/"$VENDOR"/"$DEVICE"/proprietary/vendor/lib/hw/camera.msm8996.so
 
 sed -i \
     -e 's/_ZN7qcamera17QCameraParameters16setQuadraCfaModeEjb/_ZN7qcamera17QCameraParameters16setQuadraCfaModSHIM/' \

--- a/init/init_oneplus3.cpp
+++ b/init/init_oneplus3.cpp
@@ -116,7 +116,6 @@ void load_op3(const char *model) {
     property_override_dual("ro.product.device", "ro.vendor.product.device", "OnePlus3");
     property_override("ro.build.description", "OnePlus3-user 8.0.0 OPR1.170623.032 31 release-keys");
     property_override_dual("ro.build.fingerprint", "ro.vendor.build.fingerprint", "OnePlus/OnePlus3/OnePlus3:8.0.0/OPR1.170623.032/02281230:user/release-keys");
-    android::init::property_set("ro.vendor.patch.level", "Open Beta 37");
 }
 
 void load_op3t(const char *model) {
@@ -126,18 +125,6 @@ void load_op3t(const char *model) {
     property_override("ro.build.description", "OnePlus3-user 8.0.0 OPR1.170623.032 31 release-keys");
     property_override_dual("ro.build.fingerprint", "ro.vendor.build.fingerprint", "OnePlus/OnePlus3/OnePlus3T:8.0.0/OPR1.170623.032/02281230:user/release-keys");
     property_set("ro.power_profile.override", "power_profile_3t");
-    android::init::property_set("ro.vendor.patch.level", "Open Beta 28");
-}
-
-static void import_panel_prop(const std::string& key, const std::string& value, bool for_emulator) {
-    if (key.empty()) return;
-
-    if (key.compare("mdss_mdp.panel") == 0) {
-        if (value.find("s6e3fa3") != std::string::npos)
-            property_override("ro.product.panel", "samsung_s6e3fa3_1080p");
-        if (value.find("s6e3fa5") != std::string::npos)
-            property_override("ro.product.panel", "samsung_s6e3fa5_1080p");
-    }
 }
 
 void vendor_load_properties() {

--- a/rootdir/etc/recovery.fstab
+++ b/rootdir/etc/recovery.fstab
@@ -28,17 +28,11 @@
 # Non A/B, non-split(no vendor.img) recovery.fstab variant.
 #device         mount point      fstype        [device2] [length=]
 
-/dev/block/bootdevice/by-name/boot               /boot             emmc    defaults                                                                                                        defaults
-/dev/block/bootdevice/by-name/recovery           /recovery         emmc    defaults                                                                                                        defaults
-/dev/block/bootdevice/by-name/system             /system           ext4    ro,barrier=1                                                                                                    wait
-/dev/block/bootdevice/by-name/userdata           /data             f2fs    nosuid,nodev,noatime,discard,nodiratime                                                                         wait,check,encryptable=footer,formattable,length=-16384
-/dev/block/bootdevice/by-name/userdata           /data             ext4    nosuid,nodev,noatime,barrier=1,noauto_da_alloc                                                                  wait,check,encryptable=footer,formattable,length=-16384
-/dev/block/bootdevice/by-name/cache              /cache            f2fs    nosuid,nodev,noatime,inline_xattr,flush_merge,data_flush                                                        wait,check,formattable
-/dev/block/bootdevice/by-name/cache              /cache            ext4    nosuid,nodev,noatime,barrier=1                                                                                  wait,check,formattable
-/dev/block/bootdevice/by-name/persist            /persist          ext4    nosuid,nodev,barrier=1                                                                                          wait
-/dev/block/bootdevice/by-name/dsp                /dsp              ext4    ro,nosuid,nodev,barrier=1                                                                                       wait
-/dev/block/bootdevice/by-name/modem              /firmware         vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0                    wait
-/dev/block/bootdevice/by-name/bluetooth          /bt_firmware      vfat    ro,shortname=lower,uid=1002,gid=3002,dmask=222,fmask=333,context=u:object_r:bt_firmware_file:s0                 wait
-/dev/block/bootdevice/by-name/misc               /misc             emmc    defaults                                                                                                        defaults
-
-/devices/soc/6a00000.ssusb/6a00000.dwc3/xhci-hcd.0.auto/usb* auto auto defaults voldmanaged=usbdisk:auto
+/dev/block/bootdevice/by-name/system       /system         ext4    ro,barrier=1                                                    wait,verify
+/dev/block/bootdevice/by-name/cache        /cache          f2fs    noatime,nosuid,nodev,inline_xattr,flush_merge,data_flush        wait,check
+/dev/block/bootdevice/by-name/cache        /cache          ext4    noatime,nosuid,nodev,barrier=1,data=ordered                     wait,check
+/dev/block/bootdevice/by-name/userdata     /data           f2fs    noatime,nosuid,nodev,inline_xattr,data_flush                    wait,check,encryptable=footer
+/dev/block/bootdevice/by-name/userdata     /data           ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc     wait,check,encryptable=footer
+/dev/block/bootdevice/by-name/boot         /boot           emmc    defaults                                                        defaults
+/dev/block/bootdevice/by-name/recovery     /recovery       emmc    defaults                                                        defaults
+/dev/block/bootdevice/by-name/misc         /misc           emmc    defaults                                                        defaults

--- a/sepolicy/hal_graphics_composer_default.te
+++ b/sepolicy/hal_graphics_composer_default.te
@@ -1,1 +1,4 @@
-get_prop(hal_graphics_composer_default, diag_prop);
+get_prop(hal_graphics_composer_default, diag_prop)
+
+allow hal_graphics_composer_default sysfs_graphics:lnk_file { read };
+

--- a/sepolicy/mm-pp-daemon.te
+++ b/sepolicy/mm-pp-daemon.te
@@ -1,0 +1,3 @@
+set_prop(mm-pp-daemon, diag_prop)
+
+allow mm-pp-daemon sysfs_graphics:lnk_file { read };

--- a/sepolicy/mm-qcamerad.te
+++ b/sepolicy/mm-qcamerad.te
@@ -3,6 +3,7 @@ allow mm-qcamerad camera_socket:sock_file { create unlink };
 allow mm-qcamerad permission_service:service_manager find;
 allow mm-qcamerad system_server:unix_stream_socket rw_socket_perms;
 allow mm-qcamerad sensorservice_service:service_manager find;
+allow mm-qcamerad sysfs_graphics:file r_file_perms;
 binder_call(mm-qcamerad, servicemanager);
 binder_use(mm-qcamerad);
 set_prop(mm-qcamerad, diag_prop);

--- a/sepolicy/system_app.te
+++ b/sepolicy/system_app.te
@@ -2,6 +2,7 @@ allow system_app time_daemon:unix_stream_socket connectto;
 allow system_app proc_touchpanel:dir search;
 allow system_app proc_touchpanel:file rw_file_perms;
 allow system_app sysfs_fpc:file write;
+allow system_app sysfs_vibrator:file write;
 
 binder_call(system_app, ifaadaemon)
 binder_call(system_app, remosaic_daemon)

--- a/setup-makefiles.sh
+++ b/setup-makefiles.sh
@@ -28,9 +28,9 @@ INITIAL_COPYRIGHT_YEAR=2016
 MY_DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$MY_DIR" ]]; then MY_DIR="$PWD"; fi
 
-GZOSP_ROOT="$MY_DIR"/../../..
+XTENDED_ROOT="$MY_DIR"/../../..
 
-HELPER="$GZOSP_ROOT"/vendor/gzosp/build/tools/extract_utils.sh
+HELPER="$XTENDED_ROOT"/vendor/xtended/build/tools/extract_utils.sh
 if [ ! -f "$HELPER" ]; then
     echo "Unable to find helper script at $HELPER"
     exit 1
@@ -38,7 +38,7 @@ fi
 . "$HELPER"
 
 # Initialize the helper
-setup_vendor "$DEVICE" "$VENDOR" "$GZOSP_ROOT"
+setup_vendor "$DEVICE" "$VENDOR" "$XTENDED_ROOT"
 
 # Copyright headers and guards
 write_headers


### PR DESCRIPTION
this commit contains the following changes:
* sync to lineageos sources (recovery.fstab, init.target.rc, ...)
* disable kernel cmd permissive line
* fix some gzosp leftovers in scripts
* add permissions for dash
* add permissions for grahpics_composer
* add permissions for mm-camerad
* add permissions for vibrate control